### PR TITLE
Change to reproduce the delay in creating the control storage layout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.5 // indirect
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	cloud.google.com/go/iam v1.2.1 // indirect
+	cloud.google.com/go/longrunning v0.6.1 // indirect
 	cloud.google.com/go/monitoring v1.21.1 // indirect
 	cloud.google.com/go/trace v1.11.1 // indirect
 	git.sr.ht/~sbinet/gg v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -565,6 +565,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/main.go
+++ b/main.go
@@ -8,11 +8,14 @@ import (
 	"io"
 	"log"
 	"net/http"
+
 	// Register the pprof endpoints under the web server root at /debug/pprof
 	_ "net/http/pprof"
 	"os"
 	"strconv"
 	"time"
+
+	control "cloud.google.com/go/storage/control/apiv2"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -26,6 +29,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 )
 
 var (
@@ -137,6 +141,37 @@ func CreateGrpcClient(ctx context.Context) (client *storage.Client, err error) {
 	return storage.NewGRPCClient(ctx, option.WithGRPCConnectionPool(grpcConnPoolSize), option.WithTokenSource(tokenSource), storage.WithDisabledClientMetrics())
 }
 
+// CreateStorageControlClient creates control client.
+func CreateAndPerformControlClientOperation(ctx context.Context) (err error) {
+	tokenSource, err := GetTokenSource(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	// , storage.WithDisabledClientMetrics()
+	ctrlClient, err := control.NewStorageControlClient(ctx, option.WithGRPCConnectionPool(grpcConnPoolSize), option.WithTokenSource(tokenSource))
+	if err != nil {
+		return err
+	}
+
+	startTime := time.Now()
+	var callOptions []gax.CallOption
+	storageLayout, err := ctrlClient.GetStorageLayout(context.Background(), &controlpb.GetStorageLayoutRequest{
+		Name:      fmt.Sprintf("projects/_/buckets/%s/storageLayout", *bucketName),
+		Prefix:    "",
+		RequestId: "",
+	}, callOptions...)
+
+	fmt.Println("storageLayoutFetch time: ", time.Since(startTime).Seconds())
+	timeCheck1 := time.Now()
+	namespace := storageLayout.GetHierarchicalNamespace()
+	fmt.Println("namespace fetch time: ", time.Since(timeCheck1).Seconds())
+	fmt.Println(namespace)
+
+	return nil
+
+}
+
 // ReadObject creates reader object corresponding to workerID with the help of bucketHandle.
 func ReadObject(ctx context.Context, workerID int, bucketHandle *storage.BucketHandle) (err error) {
 
@@ -216,8 +251,15 @@ func main() {
 	var err error
 	if *clientProtocol == "http" {
 		client, err = CreateHTTPClient(ctx, false)
-	} else {
+	} else if *clientProtocol == "grpc" {
 		client, err = CreateGrpcClient(ctx)
+	} else {
+		err := CreateAndPerformControlClientOperation(ctx)
+		if err != nil {
+			fmt.Printf("while creating the client: %v", err)
+			os.Exit(1)	
+		}
+		os.Exit(0)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Command to run: `time go run . --bucket <bucket_name> --client-protocol control`
Output looks like: 
```
storageLayoutFetch time:  10.053219577
namespace fetch time:  3.7e-08
enabled:true

real    0m11.112s
user    0m2.609s
sys     0m1.036s
```
